### PR TITLE
Add double tap gesture to zoom in and out

### DIFF
--- a/Sources/SwiftUIImageViewer/SwiftUIImageViewer.swift
+++ b/Sources/SwiftUIImageViewer/SwiftUIImageViewer.swift
@@ -10,6 +10,9 @@ public struct SwiftUIImageViewer: View {
     @State private var offset: CGPoint = .zero
     @State private var lastTranslation: CGSize = .zero
 
+    private let defaultScale: CGFloat = 1
+    private let zoomedScale: CGFloat = 2
+
     public init(image: Image) {
         self.image = image
     }
@@ -24,10 +27,26 @@ public struct SwiftUIImageViewer: View {
                     .offset(x: offset.x, y: offset.y)
                     .gesture(makeDragGesture(size: proxy.size))
                     .gesture(makeMagnificationGesture(size: proxy.size))
+                    .gesture(makeDoubleTapGesture(size: proxy.size))
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .edgesIgnoringSafeArea(.all)
         }
+    }
+    
+    private func makeDoubleTapGesture(size: CGSize) -> some Gesture {
+        TapGesture(count: 2)
+            .onEnded {
+                withAnimation {
+                    if scale != defaultScale {
+                        scale = defaultScale
+                        offset = .zero
+                    } else {
+                        scale = zoomedScale
+                        adjustMaxOffset(size: size)
+                    }
+                }
+            }
     }
 
     private func makeMagnificationGesture(size: CGSize) -> some Gesture {


### PR DESCRIPTION
Fairly simple way to add double tap to zoom in or out. Ideally we would want to have a way to detect tapped location and zoom in on that, but for now, it only zooms on center of the image.